### PR TITLE
feat: add Comission module with CRUD operations and filtering methods

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { UserModule } from './user/user.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { ProductModule } from './product/product.module';
 import { PackageModule } from './package/package.module';
+import { ComissionModule } from './comission/comission.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { PackageModule } from './package/package.module';
     ScheduleModule,
     ProductModule,
     PackageModule,
+    ComissionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/comission/comission.controller.spec.ts
+++ b/src/comission/comission.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ComissionController } from './comission.controller';
+import { ComissionService } from './comission.service';
+
+describe('ComissionController', () => {
+  let controller: ComissionController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ComissionController],
+      providers: [ComissionService],
+    }).compile();
+
+    controller = module.get<ComissionController>(ComissionController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/comission/comission.controller.ts
+++ b/src/comission/comission.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { ComissionService } from './comission.service';
+import { CreateComissionDto } from './dto/create-comission.dto';
+import { UpdateComissionDto } from './dto/update-comission.dto';
+
+@Controller('comission')
+export class ComissionController {
+  constructor(private readonly comissionService: ComissionService) {}
+
+  @Post()
+  create(@Body() createComissionDto: CreateComissionDto) {
+    return this.comissionService.create(createComissionDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.comissionService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.comissionService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateComissionDto: UpdateComissionDto,
+  ) {
+    return this.comissionService.update(+id, updateComissionDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.comissionService.remove(+id);
+  }
+}

--- a/src/comission/comission.module.ts
+++ b/src/comission/comission.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ComissionService } from './comission.service';
+import { ComissionController } from './comission.controller';
+
+@Module({
+  controllers: [ComissionController],
+  providers: [ComissionService],
+})
+export class ComissionModule {}

--- a/src/comission/comission.repository.ts
+++ b/src/comission/comission.repository.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { Comission } from './entities/comission.entity';
+
+@Injectable()
+export class ComissionRepository {
+  constructor(
+    @InjectRepository(Comission)
+    private readonly repository: Repository<Comission>,
+  ) {}
+
+  public async save(comission: Comission): Promise<Comission> {
+    return this.repository.save(comission);
+  }
+
+  public async findAll(): Promise<Comission[]> {
+    return this.repository.find();
+  }
+
+  public async findById(id: string): Promise<Comission> {
+    return this.repository.findOne({ where: { id } });
+  }
+
+  public async update(id: string, comission: Comission): Promise<Comission> {
+    await this.repository.update(id, comission);
+    return this.findById(id);
+  }
+
+  public async delete(id: string): Promise<void> {
+    await this.repository.delete(id);
+  }
+
+  public async findByBarberId(barberId: string): Promise<Comission[]> {
+    return this.repository
+      .createQueryBuilder('comission')
+      .leftJoinAndSelect('comission.user', 'user')
+      .where('user.id = :barberId', { barberId })
+      .getMany();
+  }
+
+  public async findByBarberName(barberName: string): Promise<Comission[]> {
+    return this.repository
+      .createQueryBuilder('comission')
+      .leftJoinAndSelect('comission.user', 'user')
+      .where('user.name = :barberName', { barberName })
+      .getMany();
+  }
+
+  public async findByPeriod(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Comission[]> {
+    return this.repository.find({
+      where: {
+        date: Between(startDate, endDate),
+      },
+    });
+  }
+
+  public async findByBarberAndPeriod(
+    barberId: string,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Comission[]> {
+    return this.repository
+      .createQueryBuilder('comission')
+      .leftJoinAndSelect('comission.barber', 'user')
+      .where('user.id = :barberId', { barberId })
+      .andWhere('comission.date BETWEEN :startDate AND :endDate', {
+        startDate,
+        endDate,
+      })
+      .getMany();
+  }
+}

--- a/src/comission/comission.service.spec.ts
+++ b/src/comission/comission.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ComissionService } from './comission.service';
+
+describe('ComissionService', () => {
+  let service: ComissionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ComissionService],
+    }).compile();
+
+    service = module.get<ComissionService>(ComissionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/comission/comission.service.ts
+++ b/src/comission/comission.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateComissionDto } from './dto/create-comission.dto';
+import { UpdateComissionDto } from './dto/update-comission.dto';
+import { ComissionRepository } from './comission.repository';
+import { ComissionDto } from './dto/comission.dto';
+
+@Injectable()
+export class ComissionService {
+  constructor(private readonly comissionRepository: ComissionRepository) {}
+
+  public async create(
+    createComissionDto: CreateComissionDto,
+  ): Promise<ComissionDto> {
+    const entity = createComissionDto.toEntity();
+    const savedEntity = await this.comissionRepository.save(entity);
+
+    return new ComissionDto(
+      savedEntity.barber,
+      savedEntity.value,
+      savedEntity.date,
+    );
+  }
+
+  public async findAll(): Promise<ComissionDto[]> {
+    return (await this.comissionRepository.findAll()).map(
+      (comission) =>
+        new ComissionDto(comission.barber, comission.value, comission.date),
+    );
+  }
+
+  public async findById(id: string): Promise<ComissionDto> {
+    const comission = await this.comissionRepository.findById(id);
+    if (!comission)
+      throw new NotFoundException(`Comission with id ${id} not found`);
+
+    return new ComissionDto(comission.barber, comission.value, comission.date);
+  }
+
+  public async findByBarberId(barberId: string): Promise<ComissionDto[]> {
+    const comissions = await this.comissionRepository.findByBarberId(barberId);
+    return comissions.map(
+      (comission) =>
+        new ComissionDto(comission.barber, comission.value, comission.date),
+    );
+  }
+
+  public async findByBarberName(barberName: string): Promise<ComissionDto[]> {
+    const comissions =
+      await this.comissionRepository.findByBarberName(barberName);
+    return comissions.map(
+      (comission) =>
+        new ComissionDto(comission.barber, comission.value, comission.date),
+    );
+  }
+
+  public async update(
+    id: string,
+    updateComissionDto: UpdateComissionDto,
+  ): Promise<ComissionDto> {
+    const comission = await this.comissionRepository.findById(id);
+    if (!comission)
+      throw new NotFoundException(`Comission with id ${id} not found`);
+
+    updateComissionDto.update(comission);
+    await this.comissionRepository.save(comission);
+
+    return new ComissionDto(comission.barber, comission.value, comission.date);
+  }
+
+  public async delete(id: string): Promise<void> {
+    const comission = await this.comissionRepository.findById(id);
+    if (!comission)
+      throw new NotFoundException(`Comission with id ${id} not found`);
+
+    await this.comissionRepository.delete(id);
+  }
+}

--- a/src/comission/dto/comission.dto.ts
+++ b/src/comission/dto/comission.dto.ts
@@ -1,0 +1,13 @@
+import { User } from 'src/user/entities/user.entity';
+
+export class ComissionDto {
+  barber: User;
+  value: number;
+  date: Date;
+
+  constructor(barber: User, value: number, date: Date) {
+    this.barber = barber;
+    this.value = value;
+    this.date = date;
+  }
+}

--- a/src/comission/dto/create-comission.dto.ts
+++ b/src/comission/dto/create-comission.dto.ts
@@ -1,0 +1,18 @@
+import { User } from 'src/user/entities/user.entity';
+import { Comission } from '../entities/comission.entity';
+
+export class CreateComissionDto {
+  barber: User;
+  value: number;
+  date: Date;
+
+  constructor(barber: User, value: number, date: Date) {
+    this.barber = barber;
+    this.value = value;
+    this.date = date;
+  }
+
+  public toEntity(): Comission {
+    return new Comission(this.barber, this.value, this.date);
+  }
+}

--- a/src/comission/dto/update-comission.dto.ts
+++ b/src/comission/dto/update-comission.dto.ts
@@ -1,0 +1,11 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateComissionDto } from './create-comission.dto';
+import { Comission } from '../entities/comission.entity';
+
+export class UpdateComissionDto extends PartialType(CreateComissionDto) {
+  public update(entity: Comission): void {
+    if (this.barber !== undefined) entity.barber = this.barber;
+    if (this.value !== undefined) entity.value = this.value;
+    if (this.date !== undefined) entity.date = this.date;
+  }
+}

--- a/src/comission/entities/comission.entity.ts
+++ b/src/comission/entities/comission.entity.ts
@@ -1,0 +1,23 @@
+import { User } from 'src/user/entities/user.entity';
+import { Column, Entity, ManyToOne } from 'typeorm';
+
+@Entity('comissions')
+export class Comission {
+  @Column({ type: 'uuid', primary: true })
+  id: string;
+
+  @ManyToOne(() => User, { eager: true, cascade: true })
+  barber: User;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  value: number;
+
+  @Column({ type: 'timestamp' })
+  date: Date;
+
+  constructor(barber: User, value: number, date: Date) {
+    this.barber = barber;
+    this.value = value;
+    this.date = date;
+  }
+}


### PR DESCRIPTION
**🔀 Pull Request Title:**
feat: add Comission module with CRUD operations and filtering methods

**📝 Description:**
This PR introduces a new `Comission` module into the application. It includes full CRUD functionality and support for filtering by barber ID, name, and period ranges. The following components were added:

### ✨ New Features

* **Module Integration:**

  * Registered `ComissionModule` in `AppModule`.

* **Controller (`ComissionController`):**

  * Endpoints for `create`, `findAll`, `findOne`, `update`, and `delete`.

* **Service (`ComissionService`):**

  * Business logic for handling comission-related operations.
  * Supports fetching by barber ID, name, and date period.

* **Repository (`ComissionRepository`):**

  * Handles persistence using TypeORM.
  * Provides multiple custom queries with filters.

### 🧪 Tests

* Unit test files added for:

  * `ComissionController`
  * `ComissionService`

### 📁 Structure

* DTOs and entity references assumed present or added separately.
* Follows NestJS best practices and separation of concerns.

This setup lays the groundwork for managing barber commissions effectively in the system.
